### PR TITLE
Fix issues under multi-application configuration

### DIFF
--- a/recipes/deploy.rb
+++ b/recipes/deploy.rb
@@ -1,5 +1,8 @@
 node[:deploy].each do |application, deploy|
-  if deploy['sidekiq']
+  if deploy[:application_type] != 'rails'
+    Chef::Log.debug("skipping sidekiq config for #{application} because it's not supposed to be deployed right now.")
+    next
+  elsif deploy['sidekiq']
     sidekiq_config = deploy['sidekiq']
     release_path = ::File.join(deploy[:deploy_to], 'current')
     start_command = sidekiq_config['start_command'] || "bundle exec sidekiq -e production -C config/sidekiq.yml -r ./config/boot.rb 2>&1 >> log/sidekiq.log"


### PR DESCRIPTION
When deploying only one application (using the 'deploy' recipe), this block *should* only run for the application being deployed.
However, because sidekiq values are set in the stack JSON, the application json block for certain apps with sidekiq will exist even when it's not the application under deployment, but it won't be fully populated by opwsorks. That means that the sidekiq upstart file might be overwritten with incomplete data (specifically the environment variables will be missing), resulting in a broken upstart for apps that are not supposed to be deployed.
['application_type'] appears to be set only when an application is specifically earmarked for immediate deployment. This approach is used in a number of places in the opsworks official Chef 11 recipes. I am sure there are shortcomings to this, but it's better than breaking the upstart system.